### PR TITLE
Paging link can contain format characters, unescape them first

### DIFF
--- a/registry/catalog.go
+++ b/registry/catalog.go
@@ -1,6 +1,7 @@
 package registry
 
 import "github.com/peterhellberg/link"
+import nurl "net/url"
 
 type catalogResponse struct {
 	Repositories []string `json:"repositories"`
@@ -22,7 +23,8 @@ func (r *Registry) Catalog(u string) ([]string, error) {
 
 	for _, l := range link.ParseHeader(h) {
 		if l.Rel == "next" {
-			repos, err := r.Catalog(l.URI)
+			unescaped, _ := nurl.QueryUnescape(l.URI)
+			repos, err := r.Catalog(unescaped)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
If the catalog of a registry has a lot of entries, a paging link is return, this link will contain golang format characters:

```html
Link: </v2/_catalog?last=usernam%2Fimage&n=100>; rel="next"
```

To prevent format errors, unescape the link first.