### PR TITLE
Make tls verification optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func preload(c *cli.Context) (err error) {
 			}
 
 			// create the registry client
-			r, err = registry.New(auth, c.GlobalBool("debug"))
+			r, err = registry.New(auth, c.GlobalBool("debug"), c.GlobalBool("skipverify"))
 			if err != nil {
 				return err
 			}
@@ -68,6 +68,10 @@ func main() {
 		cli.BoolFlag{
 			Name:  "debug, d",
 			Usage: "run in debug mode",
+		},
+		cli.BoolFlag{
+			Name:  "skipverify, k",
+			Usage: "do not verify tls certificates",
 		},
 		cli.StringFlag{
 			Name:  "username, u",

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -33,8 +33,11 @@ func Log(format string, args ...interface{}) {
 }
 
 // New creates a new Registry struct with the given URL and credentials.
-func New(auth types.AuthConfig, debug bool) (*Registry, error) {
-	transport := http.DefaultTransport
+func New(auth types.AuthConfig, debug bool, skipverify bool) (*Registry, error) {
+	transport := http.DefaultTransport.(*http.Transport)
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: skipverify,
+	}
 
 	return newFromTransport(auth, transport, debug)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,7 @@ func main() {
 		}
 
 		// create the registry client
-		r, err := registry.New(auth, c.GlobalBool("debug"))
+		r, err := registry.New(auth, c.GlobalBool("debug"), c.GlobalBool("skipverify"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If the registry is running with a self signed certificate, all commands will fail because certificate authority cant be verified. Add a flag to disable tls verification.