### PR TITLE
Fix Issue 8 by reporting the error correctly and using a moveFile instead of os.Rename across mount points

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -111,7 +111,7 @@ func main() {
 
 		// create the initial index
 		if err := createStaticIndex(r, staticDir, c.GlobalString("clair")); err != nil {
-			return err
+			return cli.NewExitError(fmt.Sprintf("Error creating index: %s", err.Error()), 1)
 		}
 
 		// parse the duration


### PR DESCRIPTION
os.Rename only works across the same mountpoint, since it creates a new hardlink and
unlinks the old one.
Since we generated the index in /tmp, which is most likely not the final endpoint, this
often does not work.