### PR TITLE
Allow for non-SSL access

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ COMMANDS:
 GLOBAL OPTIONS:
    --debug, -d                 run in debug mode
    --insecure, -k              do not verify tls certificates
+   --force-non-ssl, -F         force allow use of non-ssl
    --username value, -u value  username for the registry
    --password value, -p value  password for the registry
    --registry value, -r value  URL to the private registry (ex. r.j3ss.co)

--- a/main.go
+++ b/main.go
@@ -45,6 +45,11 @@ func preload(c *cli.Context) (err error) {
 				return err
 			}
 
+			// Prevent non-ssl unless explicitly forced
+			if !c.GlobalBool("force-non-ssl") && strings.HasPrefix(auth.ServerAddress, "http:") {
+				return fmt.Errorf("Attempt to use insecure protocol! Use non-ssl option to force")
+			}
+
 			// create the registry client
 			if c.GlobalBool("insecure") {
 				r, err = registry.NewInsecure(auth, c.GlobalBool("debug"))
@@ -52,9 +57,6 @@ func preload(c *cli.Context) (err error) {
 					return err
 				}
 			} else {
-				if strings.HasPrefix(auth.ServerAddress, "http:") {
-					return errors.New("Attempt to use insecure protocol! Use insecure option to force")
-				}
 				r, err = registry.New(auth, c.GlobalBool("debug"))
 				if err != nil {
 					return err
@@ -81,7 +83,11 @@ func main() {
 		},
 		cli.BoolFlag{
 			Name:  "insecure, k",
-			Usage: "do not verify tls certificates / allow use of http",
+			Usage: "do not verify tls certificates",
+		},
+		cli.BoolFlag{
+			Name:  "force-non-ssl, f",
+			Usage: "force allow use of non-ssl",
 		},
 		cli.StringFlag{
 			Name:  "username, u",

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func preload(c *cli.Context) (err error) {
 				}
 			} else {
 				if strings.HasPrefix(auth.ServerAddress, "http:") {
-					return errors.New("ERROR: Attempt to use insecure protocol! Use insecure option to force.")
+					return errors.New("Attempt to use insecure protocol! Use insecure option to force")
 				}
 				r, err = registry.New(auth, c.GlobalBool("debug"))
 				if err != nil {

--- a/main.go
+++ b/main.go
@@ -52,6 +52,9 @@ func preload(c *cli.Context) (err error) {
 					return err
 				}
 			} else {
+				if strings.HasPrefix(auth.ServerAddress, "http:") {
+					return errors.New("ERROR: Attempt to use insecure protocol! Use insecure option to force.")
+				}
 				r, err = registry.New(auth, c.GlobalBool("debug"))
 				if err != nil {
 					return err
@@ -78,7 +81,7 @@ func main() {
 		},
 		cli.BoolFlag{
 			Name:  "insecure, k",
-			Usage: "do not verify tls certificates",
+			Usage: "do not verify tls certificates / allow use of http",
 		},
 		cli.StringFlag{
 			Name:  "username, u",


### PR DESCRIPTION
This change allows for using reg against non-SSL registries when the user supplies an explicit protocol (http://). It does not change the existing, default behavior of defaulting to SSL if no protocol is specified.

We have an internal, private registry so I was able to test it out there and it seems to work with no issues.

P.S. This is my very first time writing ANY Go code outside of small tests. Apologies for any ignorance... :-)

