### PR TITLE
RFC: some enhancements for registries with lots of images

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -117,7 +117,7 @@ func isTokenDemand(resp *http.Response) (*authService, error) {
 func (r *Registry) Token(url string) (string, error) {
 	r.Logf("registry.token url=%s", url)
 
-	resp, err := http.Get(url)
+	resp, err := r.Client.Get(url)
 	if err != nil {
 		return "", err
 	}
@@ -129,7 +129,7 @@ func (r *Registry) Token(url string) (string, error) {
 	}
 
 	authReq, err := a.Request(r.Username, r.Password)
-	resp, err = http.DefaultClient.Do(authReq)
+	resp, err = r.Client.Do(authReq)
 	if err != nil {
 		return "", err
 	}

--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -123,8 +123,8 @@ func (r *Registry) Token(url string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	a, err := parseAuthHeader(resp.Header)
-	if err != nil {
+	a, err := isTokenDemand(resp)
+	if err != nil || a == nil {
 		return "", err
 	}
 

--- a/server/README.md
+++ b/server/README.md
@@ -29,6 +29,7 @@ GLOBAL OPTIONS:
    --username value, -u value  username for the registry
    --password value, -p value  password for the registry
    --registry value, -r value  URL to the private registry (ex. r.j3ss.co)
+   --insecure, -k              do not verify tls certificates of registry
    --port value                port for server to run on (default: "8080")
    --cert value                path to ssl cert
    --key value                 path to ssl key

--- a/server/server.go
+++ b/server/server.go
@@ -291,8 +291,6 @@ func createStaticIndex(r *registry.Registry, staticDir, clairURI string, debug b
 						wg.Done()
 						<-sem
 					}()
-					throttle := time.Tick(time.Duration(time.Duration((i+1)*(j+1)*4) * time.Second))
-					<-throttle
 
 					logrus.Infof("creating vuln static page for %s:%s", repo, tag)
 

--- a/server/server.go
+++ b/server/server.go
@@ -32,6 +32,7 @@ var (
 	updating = false
 	wg       sync.WaitGroup
 	tmpl     *template.Template
+	r        *registry.Registry
 )
 
 // preload initializes any global options and configuration
@@ -69,6 +70,10 @@ func main() {
 			Name:  "registry, r",
 			Usage: "URL to the private registry (ex. r.j3ss.co)",
 		},
+		cli.BoolFlag{
+			Name:  "insecure, k",
+			Usage: "do not verify tls certificates of registry",
+		},
 		cli.StringFlag{
 			Name:  "port",
 			Value: "8080",
@@ -99,9 +104,16 @@ func main() {
 		}
 
 		// create the registry client
-		r, err := registry.New(auth, c.GlobalBool("debug"))
-		if err != nil {
-			logrus.Fatal(err)
+		if c.GlobalBool("insecure") {
+			r, err = registry.NewInsecure(auth, c.GlobalBool("debug"))
+			if err != nil {
+				logrus.Fatal(err)
+			}
+		} else {
+			r, err = registry.New(auth, c.GlobalBool("debug"))
+			if err != nil {
+				logrus.Fatal(err)
+			}
 		}
 
 		// get the path to the static directory

--- a/server/server.go
+++ b/server/server.go
@@ -167,7 +167,7 @@ func main() {
 
 		// create the initial index
 		logrus.Info("creating initial static index")
-		if err := createStaticIndex(r, staticDir, c.GlobalString("clair"), c.GlobalBool("debug"), c.GlobalInt("workers")); err != nil {
+		if err := createStaticIndex(r, staticDir, "", c.GlobalBool("debug"), c.GlobalInt("workers")); err != nil {
 			logrus.Fatalf("Error creating index: %v", err)
 		}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -95,13 +95,18 @@ func NewClairLayer(r *registry.Registry, image string, fsLayers []schema1.FSLaye
 		return nil, err
 	}
 
+	h := make(map[string]string)
+	if token != "" {
+		h = map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", token),
+		}
+	}
+
 	return &clair.Layer{
 		Name:       fsLayers[index].BlobSum.String(),
 		Path:       p,
 		ParentName: parentName,
 		Format:     "Docker",
-		Headers: map[string]string{
-			"Authorization": fmt.Sprintf("Bearer %s", token),
-		},
+		Headers:    h,
 	}, nil
 }


### PR DESCRIPTION
Hi Jess,

make some more enhancements:
- always use the http client from registry, to have insecure settings available.
- check if token is required
- when a lot of images are stored, mem usage goes through roof because  vulns scans are started for all images in parallel. Make the parallelism configurable.

if you prefer one PR for every modification, please bother me.