### PR TITLE
Fix http basic auth if protocol is missing

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -68,7 +68,7 @@ func newFromTransport(auth types.AuthConfig, transport http.RoundTripper, debug 
 	}
 	basicAuthTransport := &BasicTransport{
 		Transport: tokenTransport,
-		URL:       auth.ServerAddress,
+		URL:       url,
 		Username:  auth.Username,
 		Password:  auth.Password,
 	}


### PR DESCRIPTION
Basic auth only worked if a full url was supplied.  The reason is that
BasicTransport.RoundTrip checked if the resulting request URL has a the
transport's URL as a prefix.

This is fixed by setting the transport's URL to the canonical URL that is
computed a few lines earlier.

***

Given how rusty (no pun intended) my Go skills are and I’m too obtuse to get Apple’s lldb work properly with Go, don’t ask me how long and how many log calls this tiny fix took. 🙈 

I couldn’t find any relevant tests that need to be fixed?  Sadly the Docker-based tests don’t run on my Mac so I hope Travis will sort it out…

Fixes #10 