### PR TITLE
clair: add the additional legacy empty layer

### DIFF
--- a/clair/types.go
+++ b/clair/types.go
@@ -1,9 +1,21 @@
 package clair
 
+import "github.com/opencontainers/go-digest"
+
 const (
 	// EmptyLayerBlobSum is the blob sum of empty layers.
 	EmptyLayerBlobSum = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+
+	// LegacyEmptyLayerBlobSum is the blob sum of empty layers used by docker
+	// before it could support a truly empty layer.
+	LegacyEmptyLayerBlobSum = "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
 )
+
+// IsEmptyLayer determines whether the blob sum is one of the known empty
+// layers.
+func IsEmptyLayer(blobSum digest.Digest) bool {
+	return blobSum == EmptyLayerBlobSum || blobSum == LegacyEmptyLayerBlobSum
+}
 
 var (
 	// Priorities are the vulnerability priority labels.

--- a/main.go
+++ b/main.go
@@ -275,7 +275,7 @@ func main() {
 				// filter out the empty layers
 				var filteredLayers []schema1.FSLayer
 				for _, layer := range m.FSLayers {
-					if layer.BlobSum != clair.EmptyLayerBlobSum {
+					if !clair.IsEmptyLayer(layer.BlobSum) {
 						filteredLayers = append(filteredLayers, layer)
 					}
 				}


### PR DESCRIPTION
This layer was used in docker prior to being able to support truly empty
layers. It is a 1k tarball of 0s.