### PR TITLE
Fix repo with slashes, no vulnerability scan on tags page

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,8 +96,8 @@ func (rc *registryController) tagsHandler(w http.ResponseWriter, r *http.Request
 	}).Info("fetching tags")
 
 	vars := mux.Vars(r)
-	repo := vars["repo"]
-	if repo == "" {
+	repo, err := url.QueryUnescape(vars["repo"])
+	if err != nil || repo == "" {
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, "Empty repo")
 		return
@@ -198,10 +199,10 @@ func (rc *registryController) vulnerabilitiesHandler(w http.ResponseWriter, r *h
 	}).Info("fetching vulnerabilities")
 
 	vars := mux.Vars(r)
-	repo := vars["repo"]
+	repo, err := url.QueryUnescape(vars["repo"])
 	tag := vars["tag"]
 
-	if repo == "" {
+	if err != nil || repo == "" {
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, "Empty repo")
 		return

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -127,6 +127,8 @@ func (rc *registryController) tagsHandler(w http.ResponseWriter, r *http.Request
 				"func":   "tags",
 				"URL":    r.URL,
 				"method": r.Method,
+				"repo":   repo,
+				"tag":    tag,
 			}).Errorf("getting v1 manifest for %s:%s failed: %v", repo, tag, err)
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(w, "Manifest not found")
@@ -220,6 +222,8 @@ func (rc *registryController) vulnerabilitiesHandler(w http.ResponseWriter, r *h
 			"func":   "vulnerabilities",
 			"URL":    r.URL,
 			"method": r.Method,
+			"repo":   repo,
+			"tag":    tag,
 		}).Errorf("getting v1 manifest for %s:%s failed: %v", repo, tag, err)
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, "Manifest not found")

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -164,20 +164,6 @@ func (rc *registryController) tagsHandler(w http.ResponseWriter, r *http.Request
 			Created: createdDate,
 		}
 
-		if rc.cl != nil {
-			vuln, err := rc.cl.Vulnerabilities(rc.reg, repo, tag, m1)
-			if err != nil {
-				logrus.WithFields(logrus.Fields{
-					"func":   "tags",
-					"URL":    r.URL,
-					"method": r.Method,
-				}).Errorf("vulnerability scanning for %s:%s failed: %v", repo, tag, err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			rp.VulnerabilityReport = vuln
-		}
-
 		result.Repositories = append(result.Repositories, rp)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -207,16 +207,17 @@ func main() {
 
 		// create mux server
 		mux := mux.NewRouter()
+		mux.UseEncodedPath()
 
 		// static files handler
 		staticHandler := http.FileServer(http.Dir(staticDir))
-		mux.HandleFunc("/repo/{repo}", rc.tagsHandler)
-		mux.HandleFunc("/repo/{repo}/", rc.tagsHandler)
-		mux.HandleFunc("/repo/{repo}/{tag}", rc.vulnerabilitiesHandler)
-		mux.HandleFunc("/repo/{repo}/{tag}/", rc.vulnerabilitiesHandler)
-		mux.HandleFunc("/repo/{repo}/{tag}/vulns", rc.vulnerabilitiesHandler)
-		mux.HandleFunc("/repo/{repo}/{tag}/vulns/", rc.vulnerabilitiesHandler)
-		mux.HandleFunc("/repo/{repo}/{tag}/vulns.json", rc.vulnerabilitiesHandler)
+		mux.HandleFunc("/repo/{repo}/tags", rc.tagsHandler)
+		mux.HandleFunc("/repo/{repo}/tags/", rc.tagsHandler)
+		mux.HandleFunc("/repo/{repo}/tag/{tag}", rc.vulnerabilitiesHandler)
+		mux.HandleFunc("/repo/{repo}/tag/{tag}/", rc.vulnerabilitiesHandler)
+		mux.HandleFunc("/repo/{repo}/tag/{tag}/vulns", rc.vulnerabilitiesHandler)
+		mux.HandleFunc("/repo/{repo}/tag/{tag}/vulns/", rc.vulnerabilitiesHandler)
+		mux.HandleFunc("/repo/{repo}/tag/{tag}/vulns.json", rc.vulnerabilitiesHandler)
 		mux.PathPrefix("/static/").Handler(http.StripPrefix("/static/", staticHandler))
 		mux.Handle("/", staticHandler)
 

--- a/server/templates/repositories.html
+++ b/server/templates/repositories.html
@@ -27,13 +27,13 @@
             {{ range $key, $value := .Repositories }}
             <tr>
                 <td valign="top">
-                    <a href="/repo/{{ $value.Name | urlquery }}">
+                    <a href="/repo/{{ $value.Name | urlquery }}/tags">
                     {{ $value.Name }}
                     </a>
                 </td>
 
                 <td align="right" nowrap>
-                    <a href="/repo/{{ $value.Name | urlquery }}">
+                    <a href="/repo/{{ $value.Name | urlquery }}/tags">
                     <code>docker pull {{ $value.URI }}</code>
                     </a>
                 </td>

--- a/server/templates/tags.html
+++ b/server/templates/tags.html
@@ -25,12 +25,12 @@
             {{ range $key, $value := .Repositories }}
             <tr>
                 <td valign="left" nowrap>
-                    <a href="/repo/{{ $value.Name | urlquery }}/{{ $value.Tag }}/vulns">
+                    <a href="/repo/{{ $value.Name | urlquery }}/tag/{{ $value.Tag }}/vulns">
                     {{ $value.Name }}
                     </a>
                 </td>
                 <td align="right" nowrap>
-                    <a href="/repo/{{ $value.Name | urlquery }}/{{ $value.Tag }}/vulns">
+                    <a href="/repo/{{ $value.Name | urlquery }}/tag/{{ $value.Tag }}/vulns">
                     {{ $value.Tag }}
                     </a>
                 </td>
@@ -38,7 +38,7 @@
                     {{ $value.Created.Format "02 Jan, 2006 15:04:05 UTC" }}
                 </td>
                 <td align="right" nowrap>
-                    <a href="/repo/{{ $value.Name | urlquery }}/{{ $value.Tag }}/vulns" id="{{ $value.Name }}:{{ $value.Tag }}">
+                    <a href="/repo/{{ $value.Name | urlquery }}/tag/{{ $value.Tag }}/vulns" id="{{ $value.Name }}:{{ $value.Tag }}">
                       <div class="signal"></div>
                     </a>
                 </td>
@@ -54,7 +54,7 @@
     <script type="text/javascript">
       var ajaxCalls = [
         {{ range $key, $value := .Repositories }}
-          '/repo/{{ $value.Name | urlquery }}/{{ $value.Tag }}/vulns.json',
+          '/repo/{{ $value.Name | urlquery }}/tag/{{ $value.Tag }}/vulns.json',
         {{ end }}
       ];
       window.onload = function() {


### PR DESCRIPTION
- If the repo has a slash inside (namespaced) we need to adjust mux routing.
- improve tags page loading speed by removing useless vulnerability scan.