### PR TITLE
Add configurable timout for HTTP requests

### DIFF
--- a/clair/clair.go
+++ b/clair/clair.go
@@ -27,7 +27,7 @@ func Log(format string, args ...interface{}) {
 }
 
 // New creates a new Clair struct with the given URL and credentials.
-func New(url string, debug bool) (*Clair, error) {
+func New(url string, debug bool, timeout time.Duration) (*Clair, error) {
 	transport := http.DefaultTransport
 
 	errorTransport := &ErrorTransport{
@@ -43,7 +43,7 @@ func New(url string, debug bool) (*Clair, error) {
 	registry := &Clair{
 		URL: url,
 		Client: &http.Client{
-			Timeout:   time.Minute,
+			Timeout:   timeout,
 			Transport: errorTransport,
 		},
 		Logf: logf,

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jessfraz/reg/version"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/urfave/cli"
+	"time"
 )
 
 const (
@@ -98,6 +99,11 @@ func main() {
 		cli.StringFlag{
 			Name:  "registry, r",
 			Usage: "URL to the private registry (ex. r.j3ss.co)",
+		},
+		cli.StringFlag{
+			Name: "timeout",
+			Value: "1m",
+			Usage: "timeout for HTTP requests",
 		},
 	}
 	app.Commands = []cli.Command{
@@ -285,8 +291,14 @@ func main() {
 					return nil
 				}
 
+				// parse the timeout
+				timeout, err := time.ParseDuration(c.GlobalString("timeout"))
+				if err != nil {
+					logrus.Fatalf("parsing %s as duration failed: %v", c.GlobalString("timeout"), err)
+				}
+
 				// initialize clair
-				cr, err := clair.New(c.String("clair"), c.GlobalBool("debug"))
+				cr, err := clair.New(c.String("clair"), c.GlobalBool("debug"), timeout)
 				if err != nil {
 					return err
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -96,6 +96,7 @@ func main() {
 			Name:  "clair",
 			Usage: "url to clair instance",
 		},
+
 	}
 	app.Action = func(c *cli.Context) error {
 		auth, err := utils.GetAuthConfig(c)
@@ -116,9 +117,15 @@ func main() {
 			}
 		}
 
+		// parse the timeout
+		timeout, err := time.ParseDuration(c.GlobalString("timeout"))
+		if err != nil {
+			logrus.Fatalf("parsing %s as duration failed: %v", c.GlobalString("timeout"), err)
+		}
+
 		// create a clair instance if needed
 		if c.GlobalString("clair") != "" {
-			cl, err = clair.New(c.GlobalString("clair"), c.GlobalBool("debug"))
+			cl, err = clair.New(c.GlobalString("clair"), c.GlobalBool("debug"), timeout)
 			if err != nil {
 				logrus.Warnf("creation of clair failed: %v", err)
 			}


### PR DESCRIPTION
Sometimes it times out when we check certain docker images with a lot of layers in them.

So this PR adds a configurable time out for the HTTP requests.

> time="2017-10-20T15:29:49+02:00" level=fatal msg="Post http://192.168.99.100//v1/layers: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)" 