### PR TITLE
 fix a potential tabwriter panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,7 +148,8 @@ func main() {
 						if err != nil {
 							fmt.Printf("Get tags of [%s] error: %s", repo, err)
 						}
-						fmt.Fprintf(w, "%s\t%s\n", repo, strings.Join(tags, ", "))
+						out := fmt.Sprintf("%s\t%s\n", repo, strings.Join(tags, ", "))
+						w.Write([]byte(out))
 						wg.Done()
 					}(repo)
 				}


### PR DESCRIPTION
use tabwriter's native write for:
- sometimes tabwriter panic with goroutine
- goroutine with fmt.Fprintf cause dirty data