### PR TITLE
Add more useful error for bad credentials.

### DIFF
--- a/registry/authchallenge.go
+++ b/registry/authchallenge.go
@@ -10,7 +10,7 @@ import (
 var (
 	authChallengeRegex = regexp.MustCompile(
 		`^\s*Bearer\s+realm="([^"]+)",service="([^"]+)"\s*$`)
-	basicRegex = regexp.MustCompile(`^\s*Basic\s+.*$`)
+	basicRegex     = regexp.MustCompile(`^\s*Basic\s+.*$`)
 	challengeRegex = regexp.MustCompile(
 		`^\s*Bearer\s+realm="([^"]+)",service="([^"]+)",scope="([^"]+)"\s*$`)
 

--- a/registry/authchallenge.go
+++ b/registry/authchallenge.go
@@ -10,6 +10,7 @@ import (
 var (
 	authChallengeRegex = regexp.MustCompile(
 		`^\s*Bearer\s+realm="([^"]+)",service="([^"]+)"\s*$`)
+	basicRegex = regexp.MustCompile(`^\s*Basic\s+.*$`)
 	challengeRegex = regexp.MustCompile(
 		`^\s*Bearer\s+realm="([^"]+)",service="([^"]+)",scope="([^"]+)"\s*$`)
 
@@ -26,6 +27,10 @@ func parseAuthHeader(header http.Header) (*authService, error) {
 }
 
 func parseChallenge(challengeHeader string) (*authService, error) {
+	if basicRegex.MatchString(challengeHeader) {
+		return nil, nil
+	}
+
 	match := challengeRegex.FindAllStringSubmatch(challengeHeader, -1)
 
 	if len(match) != 1 {

--- a/registry/errortransport.go
+++ b/registry/errortransport.go
@@ -29,7 +29,7 @@ func (t *ErrorTransport) RoundTrip(request *http.Request) (*http.Response, error
 		return resp, err
 	}
 
-	if resp.StatusCode >= 500 {
+	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusUnauthorized {
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
The www-authenticate: basic response currently gets caught by
the token transport, which fails to parse it and spits out
a rather oblique "malformed auth challenge header" error.

Make the token transport ignore basic auth types, and make
the error transport handle any 401 responses that reach it.

Issue #38