### PR TITLE
Re-visit basic auth protected registry

### DIFF
--- a/clair/vulns.go
+++ b/clair/vulns.go
@@ -96,7 +96,7 @@ func (c *Clair) NewClairLayer(r *registry.Registry, image string, fsLayers []sch
 	if err != nil {
 		// if we get an error here of type: malformed auth challenge header: 'Basic realm="Registry Realm"'
 		// we need to use basic auth for the registry
-		if !strings.Contains(err.Error(), `malformed auth challenge header: 'Basic realm="Registry`) {
+		if !strings.Contains(err.Error(), `malformed auth challenge header: 'Basic realm="Registry`) && err.Error() != "basic auth required" {
 			return nil, err
 		}
 		useBasicAuth = true

--- a/registry/authchallenge.go
+++ b/registry/authchallenge.go
@@ -28,7 +28,7 @@ func parseAuthHeader(header http.Header) (*authService, error) {
 
 func parseChallenge(challengeHeader string) (*authService, error) {
 	if basicRegex.MatchString(challengeHeader) {
-		return nil, nil
+		return nil, fmt.Errorf("basic auth required")
 	}
 
 	match := challengeRegex.FindAllStringSubmatch(challengeHeader, -1)


### PR DESCRIPTION
Using a registry having basic auth enabled the authentication was not
submitted to Clair. This newly introduced error fixes the missing auth
but needs testing with non-basic auth protected registries.

Also maybe the test for the "malformed auth..." string can now be
removed as it does not trigger on registries with basic auth enabled?