### PR TITLE
Add option to skip ping on creating registry client

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,14 +49,16 @@ func preload(c *cli.Context) (err error) {
 				return fmt.Errorf("Attempt to use insecure protocol! Use non-ssl option to force")
 			}
 
+			skipPing := c.GlobalBool("no-ping")
+
 			// create the registry client
 			if c.GlobalBool("insecure") {
-				r, err = registry.NewInsecure(auth, c.GlobalBool("debug"))
+				r, err = registry.NewInsecure(auth, c.GlobalBool("debug"), !skipPing)
 				if err != nil {
 					return err
 				}
 			} else {
-				r, err = registry.New(auth, c.GlobalBool("debug"))
+				r, err = registry.New(auth, c.GlobalBool("debug"), !skipPing)
 				if err != nil {
 					return err
 				}
@@ -100,6 +102,10 @@ func main() {
 			Name:  "registry, r",
 			Usage: "URL to the private registry (ex. r.j3ss.co)",
 			Value: utils.DefaultDockerRegistry,
+		},
+		cli.BoolFlag{
+			Name:  "no-ping",
+			Usage: "don't ping the registry while establishing connection (usefull for registries where ping is buggy)",
 		},
 	}
 	app.Commands = []cli.Command{

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -38,25 +38,25 @@ func Log(format string, args ...interface{}) {
 }
 
 // New creates a new Registry struct with the given URL and credentials.
-func New(auth types.AuthConfig, debug bool) (*Registry, error) {
+func New(auth types.AuthConfig, debug, ping bool) (*Registry, error) {
 	transport := http.DefaultTransport
 
-	return newFromTransport(auth, transport, debug)
+	return newFromTransport(auth, transport, debug, ping)
 }
 
 // NewInsecure creates a new Registry struct with the given URL and credentials,
 // using a http.Transport that will not verify an SSL certificate.
-func NewInsecure(auth types.AuthConfig, debug bool) (*Registry, error) {
+func NewInsecure(auth types.AuthConfig, debug, ping bool) (*Registry, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
 	}
 
-	return newFromTransport(auth, transport, debug)
+	return newFromTransport(auth, transport, debug, ping)
 }
 
-func newFromTransport(auth types.AuthConfig, transport http.RoundTripper, debug bool) (*Registry, error) {
+func newFromTransport(auth types.AuthConfig, transport http.RoundTripper, debug, ping bool) (*Registry, error) {
 	url := strings.TrimSuffix(auth.ServerAddress, "/")
 
 	if !reProtocol.MatchString(url) {
@@ -95,8 +95,10 @@ func newFromTransport(auth types.AuthConfig, transport http.RoundTripper, debug 
 		Logf:     logf,
 	}
 
-	if err := registry.Ping(); err != nil {
-		return nil, err
+	if ping {
+		if err := registry.Ping(); err != nil {
+			return nil, err
+		}
 	}
 
 	return registry, nil

--- a/server/server.go
+++ b/server/server.go
@@ -105,12 +105,12 @@ func main() {
 
 		// create the registry client
 		if c.GlobalBool("insecure") {
-			r, err = registry.NewInsecure(auth, c.GlobalBool("debug"))
+			r, err = registry.NewInsecure(auth, c.GlobalBool("debug"), true)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 		} else {
-			r, err = registry.New(auth, c.GlobalBool("debug"))
+			r, err = registry.New(auth, c.GlobalBool("debug"), true)
 			if err != nil {
 				logrus.Fatal(err)
 			}


### PR DESCRIPTION
With some registries (at list with quay.io), ping seems broken.
Skipping the ping on registry.New makes other operations work.
This just conditionnaly skip pinging :)