### PR TITLE
main: add missing preconditions to commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,10 @@ func main() {
 			Aliases: []string{"rm"},
 			Usage:   "delete a specific reference of a repository",
 			Action: func(c *cli.Context) error {
+				if len(c.Args()) < 1 {
+					return fmt.Errorf("pass the name of the repository")
+				}
+
 				repo, ref, err := utils.GetRepoAndRef(c.Args()[0])
 				if err != nil {
 					return err
@@ -173,6 +177,10 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
+				if len(c.Args()) < 1 {
+					return fmt.Errorf("pass the name of the repository")
+				}
+
 				repo, ref, err := utils.GetRepoAndRef(c.Args()[0])
 				if err != nil {
 					return err
@@ -231,6 +239,10 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
+				if len(c.Args()) < 1 {
+					return fmt.Errorf("pass the name of the repository")
+				}
+
 				repo, ref, err := utils.GetRepoAndRef(c.Args()[0])
 				if err != nil {
 					return err
@@ -268,6 +280,9 @@ func main() {
 			Action: func(c *cli.Context) error {
 				if c.String("clair") == "" {
 					return errors.New("clair url cannot be empty, pass --clair")
+				}
+				if len(c.Args()) < 1 {
+					return fmt.Errorf("pass the name of the repository")
 				}
 
 				repo, ref, err := utils.GetRepoAndRef(c.Args()[0])


### PR DESCRIPTION
- fixed panic when a repository was not provided to:
  delete, manifest, download, vulns

example:
```
panic: runtime error: index out of range

goroutine 1 [running]:
main.main.func6(0xc4200889a0, 0x0, 0xc4200889a0)
	/home/pawel/go/src/github.com/jessfraz/reg/main.go:273 +0x1158
github.com/jessfraz/reg/vendor/github.com/urfave/cli.HandleAction(0x798640, 0x8307e0, 0xc4200889a0, 0x0, 0xc420336000)
	/home/pawel/go/src/github.com/jessfraz/reg/vendor/github.com/urfave/cli/app.go:501 +0xd4
github.com/jessfraz/reg/vendor/github.com/urfave/cli.Command.Run(0x816db5, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x82a797, 0x3a, 0x0, ...)
	/home/pawel/go/src/github.com/jessfraz/reg/vendor/github.com/urfave/cli/command.go:165 +0x596
github.com/jessfraz/reg/vendor/github.com/urfave/cli.(*App).Run(0xc4201b6540, 0xc4200100b0, 0xb, 0xb, 0x0, 0x0)
	/home/pawel/go/src/github.com/jessfraz/reg/vendor/github.com/urfave/cli/app.go:259 +0x7b7
main.main()
	/home/pawel/go/src/github.com/jessfraz/reg/main.go:377 +0xbde
```