### PR TITLE
clair/vulns: use basic auth when token is empty

### DIFF
--- a/clair/vulns.go
+++ b/clair/vulns.go
@@ -109,7 +109,7 @@ func (c *Clair) NewClairLayer(r *registry.Registry, image string, fsLayers []sch
 		}
 	}
 
-	if useBasicAuth {
+	if token == "" || useBasicAuth {
 		h = map[string]string{
 			"Authorization": fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(r.Username+":"+r.Password))),
 		}


### PR DESCRIPTION
- solves issue with Clair/AWS ECR combo

without it, it crashes with:
```
2018/02/15 15:35:12 clair.clair resp.Status=400 Bad Request
FATA[0001] clair error: could not find layer   
```

caused by the lack of `"Headers":{"Authorization":"Basic ...}`