### PR TITLE
main/vulns: add fixable group

### DIFF
--- a/clair/types.go
+++ b/clair/types.go
@@ -19,7 +19,7 @@ func IsEmptyLayer(blobSum digest.Digest) bool {
 
 var (
 	// Priorities are the vulnerability priority labels.
-	Priorities = []string{"Unknown", "Negligible", "Low", "Medium", "High", "Critical", "Defcon1"}
+	Priorities = []string{"Unknown", "Negligible", "Low", "Medium", "High", "Critical", "Defcon1", "Fixable"}
 )
 
 // Error describes the structure of a clair error.


### PR DESCRIPTION
TL;DR:
- add a new group of "Fixable" vulns
- exit with error on any fixable vulns
- add fixable-threshold parameter

The thinking behind the feature:
- replicate quay.io behaviour of exposing the number of fixable issues
- give the ability to fail CI builds when a fixable issue is detected

The main assumption is **fixable issues are actionable**, in contrast to CVEs you cannot address because there is no patch released.

The implementation may be not as elegant/idiomatic as it could - any **feedback appreciated**.