### PR TITLE
utils/auth: support registry URLs with protocol

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -55,6 +55,21 @@ func GetAuthConfig(username, password, registry string) (types.AuthConfig, error
 		if creds, ok := authConfigs[registry]; ok {
 			return creds, nil
 		}
+
+		// remove https:// from user input and try again
+		if strings.HasPrefix(registry, "https://") {
+			if creds, ok := authConfigs[strings.TrimPrefix(registry, "https://")]; ok {
+				return creds, nil
+			}
+		}
+
+		// remove http:// from user input and try again
+		if strings.HasPrefix(registry, "http://") {
+			if creds, ok := authConfigs[strings.TrimPrefix(registry, "http://")]; ok {
+				return creds, nil
+			}
+		}
+
 		// add https:// to user input and try again
 		// see https://github.com/jessfraz/reg/issues/32
 		if !strings.HasPrefix(registry, "https://") && !strings.HasPrefix(registry, "http://") {
@@ -62,6 +77,7 @@ func GetAuthConfig(username, password, registry string) (types.AuthConfig, error
 				return creds, nil
 			}
 		}
+		fmt.Printf("Using registry '%s' with no authentication\n", registry)
 
 		// Otherwise just use the registry with no auth.
 		return setDefaultRegistry(types.AuthConfig{
@@ -76,6 +92,7 @@ func GetAuthConfig(username, password, registry string) (types.AuthConfig, error
 	}
 
 	// Don't use any authentication.
+	fmt.Println("Not using any authentication")
 	return types.AuthConfig{}, nil
 }
 


### PR DESCRIPTION
Adds the option to pass `--reqistry` with `http://` or `https://` and still benefit from `.docker/config.json` credentials.

Either that or there could be validation that enforces the lack of protocol prefix.

Right now there's a corner case (I used latest Docker and AWS ECR) when the credentials in the file doesn't have the protocol and you pass a registry URL with the protocol - it gives up and falls back to no auth.

Before:
```
$ aws ecr get-login --region eu-west-1 --no-include-email | bash
$ reg --registry https://<redacted>.dkr.ecr.eu-west-1.amazonaws.com -d vulns --clair http://localhost:6060 <redacted>
2018/02/19 14:18:03 registry.ping url=https://<redacted>.dkr.ecr.eu-west-1.amazonaws.com/v2/
Get https://<redacted>.dkr.ecr.eu-west-1.amazonaws.com/v2/: http: non-successful response (status=401 body="Not Authorized\n")
...
```

After:
```
$ aws ecr get-login --region eu-west-1 --no-include-email | bash
$ ./reg --registry https://<redacted>.dkr.ecr.eu-west-1.amazonaws.com -d vulns --clair http://localhost:6060 <redacted>
2018/02/19 14:19:57 registry.ping url=https://<redacted>.dkr.ecr.eu-west-1.amazonaws.com/v2/
2018/02/19 14:19:58 registry.manifests uri=https://<redacted>.dkr.ecr.eu-west-1.amazonaws.com/v2/<redacted>/manifests/latest repository=<redacted> ref=latest
2018/02/19 14:19:58 registry.registry resp.Status=200 OK
...
2018/02/19 14:20:00 clair.clair resp.Status=200 OK
Found 0 vulnerabilities 
```