### PR TITLE
clair: increase HTTP client timeout to 5 minutes

### DIFF
--- a/clair/clair.go
+++ b/clair/clair.go
@@ -43,7 +43,7 @@ func New(url string, debug bool) (*Clair, error) {
 	registry := &Clair{
 		URL: url,
 		Client: &http.Client{
-			Timeout:   time.Minute,
+			Timeout:   5 * time.Minute,
 			Transport: errorTransport,
 		},
 		Logf: logf,


### PR DESCRIPTION
Allow for big layers (e.g. 500MB) to upload before timing out.

I've increased the timeout to 5 minutes, but maybe it'd be better to expose it as a cli param?

Before:
```
$ reg -d --registry <redacted>.dkr.ecr.eu-west-1.amazonaws.com -d vulns --clair http://localhost:6060 <redacted>
...
Analysing 5 layers
...
2018/02/19 13:10:31 clair.layers.post ...
FATA[0001] Post http://localhost:6060/v1/layers: dial tcp 127.0.0.1:6060: getsockopt: connection refused 

```

After:
```
$ reg --registry <redacted>.dkr.ecr.eu-west-1.amazonaws.com -d vulns --clair http://localhost:6060 <redacted>:v64a16712-dirty
...
Analysing 5 layers
2018/02/19 15:13:44 ...
2018/02/19 15:13:45 clair.clair resp.Status=201 Created
...
2018/02/19 15:14:22 clair.vulns using basic auth
2018/02/19 15:14:22 clair.layers.post ...
... (over 2 minutes elapsed) ...
2018/02/19 15:16:35 clair.clair resp.Status=201 Created
2018/02/19 15:16:35 ...
2018/02/19 15:16:35 clair.clair resp.Status=200 OK
Found 0 vulnerabilities 
```