### PR TITLE
Add force-non-ssl to registry operations

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ func createRegistryClient(domain string) (*registry.Registry, error) {
 		Insecure: insecure,
 		Debug:    debug,
 		SkipPing: skipPing,
+		NonSSL:   forceNonSSL,
 		Timeout:  timeout,
 	})
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -44,6 +44,7 @@ type Opt struct {
 	Insecure bool
 	Debug    bool
 	SkipPing bool
+	NonSSL   bool
 	Timeout  time.Duration
 	Headers  map[string]string
 }
@@ -67,7 +68,11 @@ func newFromTransport(auth types.AuthConfig, transport http.RoundTripper, opt Op
 	url := strings.TrimSuffix(auth.ServerAddress, "/")
 
 	if !reProtocol.MatchString(url) {
-		url = "https://" + url
+		if !opt.NonSSL {
+			url = "https://" + url
+		} else {
+			url = "http://" + url
+		}
 	}
 
 	tokenTransport := &TokenTransport{


### PR DESCRIPTION
I've been running registries locally and/or temporarilly and it's practical to be able to disable the SSL when querying it.

While I'm at it, would it make sense to you to switch to https://github.com/heroku/docker-registry-client, which seem to be almost the same registry API that implemented here?