### PR TITLE
when uploading layers reuse token so reader isn't closed premature.

### DIFF
--- a/registry/basictransport.go
+++ b/registry/basictransport.go
@@ -15,7 +15,7 @@ type BasicTransport struct {
 
 // RoundTrip defines the round tripper for basic auth transport.
 func (t *BasicTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if strings.HasPrefix(req.URL.String(), t.URL) {
+	if strings.HasPrefix(req.URL.String(), t.URL) && req.Header.Get("Authorization") == "" {
 		if t.Username != "" || t.Password != "" {
 			req.SetBasicAuth(t.Username, t.Password)
 		}

--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -47,7 +47,11 @@ func (t *TokenTransport) authAndRetry(authService *authService, req *http.Reques
 		return authResp, err
 	}
 
-	return t.retry(req, token)
+	response, err := t.retry(req, token)
+	if response != nil {
+		response.Header.Set("request-token", token)
+	}
+	return response, err
 }
 
 func (t *TokenTransport) auth(authService *authService) (string, *http.Response, error) {


### PR DESCRIPTION
Follow up from #96 