### PR TITLE
Add opt for custom http header

### DIFF
--- a/registry/customtransport.go
+++ b/registry/customtransport.go
@@ -1,0 +1,24 @@
+package registry
+
+import (
+	"net/http"
+)
+
+// CustomTransport defines the data structure for custom http.Request options.
+type CustomTransport struct {
+	Transport http.RoundTripper
+	Headers   map[string]string
+}
+
+// RoundTrip defines the round tripper for the error transport.
+func (t *CustomTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if len(t.Headers) != 0 {
+		for header, value := range t.Headers {
+			request.Header.Add(header, value)
+		}
+	}
+
+	resp, err := t.Transport.RoundTrip(request)
+
+	return resp, err
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -45,6 +45,7 @@ type Opt struct {
 	Debug    bool
 	SkipPing bool
 	Timeout  time.Duration
+	Headers  map[string]string
 }
 
 // New creates a new Registry struct with the given URL and credentials.
@@ -83,6 +84,10 @@ func newFromTransport(auth types.AuthConfig, transport http.RoundTripper, opt Op
 	errorTransport := &ErrorTransport{
 		Transport: basicAuthTransport,
 	}
+	customTransport := &CustomTransport{
+		Transport: errorTransport,
+		Headers:   opt.Headers,
+	}
 
 	// set the logging
 	logf := Quiet
@@ -95,7 +100,7 @@ func newFromTransport(auth types.AuthConfig, transport http.RoundTripper, opt Op
 		Domain: reProtocol.ReplaceAllString(url, ""),
 		Client: &http.Client{
 			Timeout:   opt.Timeout,
-			Transport: errorTransport,
+			Transport: customTransport,
 		},
 		Username: auth.Username,
 		Password: auth.Password,


### PR DESCRIPTION
Hi,

sometimes its required to setup custom headers because some stupid registries do only stuff if the user-agent match e.g. starts with `docker`.