### PR TITLE
Use a distinguished error value for basic auth.

### DIFF
--- a/registry/authchallenge.go
+++ b/registry/authchallenge.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,6 +13,9 @@ var (
 	bearerRegex = regexp.MustCompile(
 		`^\s*Bearer\s+(.*)$`)
 	basicRegex = regexp.MustCompile(`^\s*Basic\s+.*$`)
+
+	// ErrBasicAuth indicates that the repository requires basic rather than token authentication.
+	ErrBasicAuth = errors.New("basic auth required")
 )
 
 func parseAuthHeader(header http.Header) (*authService, error) {
@@ -25,7 +29,7 @@ func parseAuthHeader(header http.Header) (*authService, error) {
 
 func parseChallenge(challengeHeader string) (*authService, error) {
 	if basicRegex.MatchString(challengeHeader) {
-		return nil, fmt.Errorf("basic auth required")
+		return nil, ErrBasicAuth
 	}
 
 	match := bearerRegex.FindAllStringSubmatch(challengeHeader, -1)

--- a/registry/authchallenge_test.go
+++ b/registry/authchallenge_test.go
@@ -47,6 +47,14 @@ func TestParseChallenge(t *testing.T) {
 				scope:   []string{"repository:chrome:pull"},
 			},
 		},
+		{
+			header:      `Basic realm="https://r.j3ss.co/auth",service="Docker registry"`,
+			errorString: "basic auth required",
+		},
+		{
+			header:      `Basic realm="Registry Realm",service="Docker registry"`,
+			errorString: "basic auth required",
+		},
 	}
 
 	for _, tc := range challengeHeaderCases {
@@ -54,7 +62,7 @@ func TestParseChallenge(t *testing.T) {
 		if err != nil && !strings.Contains(err.Error(), tc.errorString) {
 			t.Fatalf("expected error to contain %v,  got %s", tc.errorString, err)
 		}
-		if !tc.value.equalTo(val) {
+		if err == nil && !tc.value.equalTo(val) {
 			t.Fatalf("got %v, expected %v", val, tc.value)
 		}
 

--- a/registry/tokentransport_test.go
+++ b/registry/tokentransport_test.go
@@ -1,0 +1,38 @@
+package registry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+)
+
+func TestErrBasicAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set("www-authenticate", `Basic realm="Registry Realm",service="Docker registry"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	authConfig := types.AuthConfig{
+		Username:      "j3ss",
+		Password:      "ss3j",
+		ServerAddress: ts.URL,
+	}
+	r, err := New(authConfig, Opt{Insecure: true, Debug: true})
+	if err != nil {
+		t.Fatalf("expected no error creating client, got %v", err)
+	}
+	token, err := r.Token(ts.URL)
+	if err != ErrBasicAuth {
+		t.Fatalf("expected ErrBasicAuth getting token, got %v", err)
+	}
+	if token != "" {
+		t.Fatalf("expected empty token, got %v", err)
+	}
+}


### PR DESCRIPTION
Rather than returning an error that requires pattern-matching from
`parseChallenge` when the challenge header requires basic
authentication, return a distinguished error value. This makes checking
for this error a bit easier.

This PR also updates the check in `r.Headers` to use the new error
value and adds a couple of regression tests.

I'd like to use this to enable ECR support in genuinetools/img. While
the distinguished error type isn't strictly necessary--changing `img`
to check the text of the error returned from `Registry.Token` against
`"basic auth required"` works just fine--it does feel like a somewhat
friendlier interface.