### PR TITLE
Fix: digest

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -36,6 +36,7 @@ var (
 			password: "testing",
 		},
 	}
+	registryHelper *testutils.RegistryHelper
 )
 
 func init() {
@@ -79,6 +80,11 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			testutils.RemoveContainer(dcli, dbID, clairID, regID)
 			panic(fmt.Errorf("starting registry container %s failed: %v", regConfig.config, err))
+		}
+
+		registryHelper, err = testutils.NewRegistryHelper(dcli, regConfig.username, regConfig.password, domain)
+		if err != nil {
+			panic(fmt.Errorf("creating registry helper %s failed: %v", regConfig.config, err))
 		}
 
 		flag.Parse()

--- a/registry/digest.go
+++ b/registry/digest.go
@@ -35,5 +35,5 @@ func (r *Registry) Digest(image Image) (digest.Digest, error) {
 		return "", fmt.Errorf("Got status code: %d", resp.StatusCode)
 	}
 
-	return digest.FromString(resp.Header.Get("Docker-Content-Digest")), nil
+	return digest.Parse(resp.Header.Get("Docker-Content-Digest"))
 }

--- a/remove_test.go
+++ b/remove_test.go
@@ -6,7 +6,14 @@ import (
 	"testing"
 )
 
+func teardownTest(t *testing.T) {
+	if err := registryHelper.RefillRegistry("busybox:glibc"); err != nil {
+		t.Fatalf("adding image after remove failed: +%v", err)
+	}
+}
+
 func TestRemove(t *testing.T) {
+	defer teardownTest(t)
 	// Make sure we have busybox in list.
 	out, err := run("ls", domain)
 	if err != nil {
@@ -22,6 +29,18 @@ busybox             glibc, latest, musl`
 	// Remove busybox image.
 	if out, err := run("rm", fmt.Sprintf("%s/busybox:glibc", domain)); err != nil {
 		t.Fatalf("output: %s, error: %v", out, err)
+	}
+
+	// Make sure we have removed busybox:glibc.
+	out, err = run("ls", domain)
+	if err != nil {
+		t.Fatalf("output: %s, error: %v", out, err)
+	}
+	expected = `REPO                TAGS
+alpine              3.5, latest
+busybox             latest, musl`
+	if !strings.HasSuffix(strings.TrimSpace(out), expected) {
+		t.Fatalf("expected to contain: %s\ngot: %s", expected, out)
 	}
 
 }

--- a/testutils/registry.go
+++ b/testutils/registry.go
@@ -1,0 +1,50 @@
+package testutils
+
+import (
+	"context"
+	"os"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/term"
+)
+
+// RegistryHelper implements methods to manipulate docker registry from test cases
+type RegistryHelper struct {
+	dcli *client.Client
+	auth string
+	addr string
+}
+
+// NewRegistryHelper returns RegistryHelper
+func NewRegistryHelper(dcli *client.Client, username, password, addr string) (*RegistryHelper, error) {
+	auth, err := constructRegistryAuth(username, password)
+	if err != nil {
+		return nil, err
+	}
+	return &RegistryHelper{dcli: dcli, auth: auth, addr: addr}, nil
+}
+
+// RefillRegistry adds images to a registry.
+func (r *RegistryHelper) RefillRegistry(image string) error {
+	if err := pullDockerImage(r.dcli, image); err != nil {
+		return err
+	}
+
+	if err := r.dcli.ImageTag(context.Background(), image, r.addr+"/"+image); err != nil {
+		return err
+	}
+
+	resp, err := r.dcli.ImagePush(context.Background(), r.addr+"/"+image, types.ImagePushOptions{
+		RegistryAuth: r.auth,
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Close()
+
+	fd, isTerm := term.GetFdInfo(os.Stdout)
+
+	return jsonmessage.DisplayJSONMessagesStream(resp, os.Stdout, fd, isTerm, nil)
+}


### PR DESCRIPTION
This PR fixes #122 
When getting image digest `digest.FromString` was used on `Docker-Content-Digest` header value which created digest of digest string. Now valid digest is returned and rm is working (had to change tests because remove test actually deletes image from repository and it have to be pushed again)