### PR TITLE
registry: format accept headers

### DIFF
--- a/registry/delete.go
+++ b/registry/delete.go
@@ -20,7 +20,7 @@ func (r *Registry) Delete(repository string, digest digest.Digest) (err error) {
 		return err
 	}
 
-	req.Header.Set("Accept", schema2.MediaTypeManifest)
+	req.Header.Add("Accept", fmt.Sprintf("%s;q=0.9", schema2.MediaTypeManifest))
 	resp, err := r.Client.Do(req)
 	if err != nil {
 		return err

--- a/registry/digest.go
+++ b/registry/digest.go
@@ -24,7 +24,7 @@ func (r *Registry) Digest(image Image) (digest.Digest, error) {
 		return "", err
 	}
 
-	req.Header.Set("Accept", schema2.MediaTypeManifest)
+	req.Header.Add("Accept", fmt.Sprintf("%s;q=0.9", schema2.MediaTypeManifest))
 	resp, err := r.Client.Do(req)
 	if err != nil {
 		return "", err

--- a/registry/manifest.go
+++ b/registry/manifest.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -22,8 +23,7 @@ func (r *Registry) Manifest(repository, ref string) (distribution.Manifest, erro
 		return nil, err
 	}
 
-	req.Header.Add("Accept", schema2.MediaTypeManifest)
-	req.Header.Add("Accept", manifestlist.MediaTypeManifestList)
+	req.Header.Add("Accept", fmt.Sprintf("%s,%s;q=0.9", schema2.MediaTypeManifest, manifestlist.MediaTypeManifestList))
 
 	resp, err := r.Client.Do(req)
 	if err != nil {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -130,8 +130,7 @@ func (r *Registry) getJSON(url string, response interface{}, addV2Header bool) (
 		return nil, err
 	}
 	if addV2Header {
-		req.Header.Add("Accept", schema2.MediaTypeManifest)
-		req.Header.Add("Accept", manifestlist.MediaTypeManifestList)
+		req.Header.Add("Accept", fmt.Sprintf("%s,%s;q=0.9", schema2.MediaTypeManifest, manifestlist.MediaTypeManifestList))
 	}
 	resp, err := r.Client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Multiple calls to request.Header.Add() will overwrite the last value.
This formats the value of the Accept headers correctly so that a
registry can perform content-type negotiation.

Example: https://play.golang.org/p/oYBMPyG9v-P