### PR TITLE
Fix digest resolution for GCR

### DIFF
--- a/registry/digest.go
+++ b/registry/digest.go
@@ -24,7 +24,7 @@ func (r *Registry) Digest(image Image) (digest.Digest, error) {
 		return "", err
 	}
 
-	req.Header.Add("Accept", fmt.Sprintf("%s;q=0.9", schema2.MediaTypeManifest))
+	req.Header.Add("Accept", schema2.MediaTypeManifest)
 	resp, err := r.Client.Do(req)
 	if err != nil {
 		return "", err

--- a/registry/digest_test.go
+++ b/registry/digest_test.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/genuinetools/reg/repoutils"
+)
+
+func TestDigestFromDockerHub(t *testing.T) {
+	auth, err := repoutils.GetAuthConfig("", "", "docker.io")
+	if err != nil {
+		t.Fatalf("Could not get auth config: %s", err)
+	}
+
+	r, err := New(auth, Opt{})
+	if err != nil {
+		t.Fatalf("Could not create registry instance: %s", err)
+	}
+
+	d, err := r.Digest(Image{Domain: "docker.io", Path: "library/alpine", Tag: "latest"})
+	if err != nil {
+		t.Fatalf("Could not get digest: %s", err)
+	}
+
+	if d == "" {
+		t.Error("Empty digest received")
+	}
+}
+
+func TestDigestFromGCR(t *testing.T) {
+	auth, err := repoutils.GetAuthConfig("", "", "gcr.io")
+	if err != nil {
+		t.Fatalf("Could not get auth config: %s", err)
+	}
+
+	r, err := New(auth, Opt{})
+	if err != nil {
+		t.Fatalf("Could not create registry instance: %s", err)
+	}
+
+	d, err := r.Digest(Image{Domain: "gcr.io", Path: "google_containers/hyperkube", Tag: "v1.9.9"})
+	if err != nil {
+		t.Fatalf("Could not get digest: %s", err)
+	}
+
+	if d == "" {
+		t.Error("Empty digest received")
+	}
+}


### PR DESCRIPTION
- Removes additional (for GCR unacceptable) parts from `Accept` header
- Adds tests for official docker.io and gcr.io registry

fixes #134 