### PR TITLE
Change the naming of the way Clair V3 reports are stored 

### DIFF
--- a/clair/layerutil.go
+++ b/clair/layerutil.go
@@ -52,7 +52,7 @@ func (c *Clair) NewClairV3Layer(r *registry.Registry, image string, fsLayer dist
 	}, nil
 }
 
-func (c *Clair) getLayers(r *registry.Registry, repo, tag string, filterEmpty bool) (map[int]distribution.Descriptor, error) {
+func (c *Clair) getLayers(r *registry.Registry, repo, tag string, filterEmpty bool) (map[int]distribution.Descriptor, string, error) {
 	ok := true
 	// Get the manifest to pass to clair.
 	mf, err := r.ManifestV2(repo, tag)
@@ -73,12 +73,12 @@ func (c *Clair) getLayers(r *registry.Registry, repo, tag string, filterEmpty bo
 			}
 		}
 
-		return filteredLayers, nil
+		return filteredLayers, mf.Config.Digest.String(), nil
 	}
 
 	m, err := r.ManifestV1(repo, tag)
 	if err != nil {
-		return nil, fmt.Errorf("getting the v1 manifest for %s:%s failed: %v", repo, tag, err)
+		return nil, "", fmt.Errorf("getting the v1 manifest for %s:%s failed: %v", repo, tag, err)
 	}
 
 	for i := 0; i < len(m.FSLayers); i++ {
@@ -91,5 +91,5 @@ func (c *Clair) getLayers(r *registry.Registry, repo, tag string, filterEmpty bo
 		}
 	}
 
-	return filteredLayers, nil
+	return filteredLayers, filteredLayers[0].Digest.String(), nil
 }

--- a/clair/vulns.go
+++ b/clair/vulns.go
@@ -19,7 +19,7 @@ func (c *Clair) Vulnerabilities(r *registry.Registry, repo, tag string) (Vulnera
 		VulnsBySeverity: make(map[string][]Vulnerability),
 	}
 
-	filteredLayers, err := c.getLayers(r, repo, tag, true)
+	filteredLayers, reportName, err := c.getLayers(r, repo, tag, true)
 	if err != nil {
 		return report, fmt.Errorf("getting filtered layers failed: %v", err)
 	}
@@ -42,9 +42,9 @@ func (c *Clair) Vulnerabilities(r *registry.Registry, repo, tag string) (Vulnera
 		}
 	}
 
-	report.Name = filteredLayers[0].Digest.String()
+	report.Name = reportName
 
-	vl, err := c.GetLayer(filteredLayers[0].Digest.String(), true, true)
+	vl, err := c.GetLayer(reportName, true, true)
 	if err != nil {
 		return report, err
 	}
@@ -85,7 +85,7 @@ func (c *Clair) VulnerabilitiesV3(r *registry.Registry, repo, tag string) (Vulne
 		VulnsBySeverity: make(map[string][]Vulnerability),
 	}
 
-	layers, err := c.getLayers(r, repo, tag, false)
+	layers, reportName, err := c.getLayers(r, repo, tag, false)
 	if err != nil {
 		return report, fmt.Errorf("getting filtered layers failed: %v", err)
 	}
@@ -95,7 +95,7 @@ func (c *Clair) VulnerabilitiesV3(r *registry.Registry, repo, tag string) (Vulne
 		return report, nil
 	}
 
-	report.Name = layers[0].Digest.String()
+	report.Name = reportName
 
 	clairLayers := []*clairpb.PostAncestryRequest_PostLayer{}
 	for i := len(layers) - 1; i >= 0; i-- {
@@ -110,12 +110,12 @@ func (c *Clair) VulnerabilitiesV3(r *registry.Registry, repo, tag string) (Vulne
 	}
 
 	// Post the ancestry.
-	if err := c.PostAncestry(layers[0].Digest.String(), clairLayers); err != nil {
+	if err := c.PostAncestry(reportName, clairLayers); err != nil {
 		return report, fmt.Errorf("posting ancestry failed: %v", err)
 	}
 
 	// Get the ancestry.
-	vl, err := c.GetAncestry(layers[0].Digest.String())
+	vl, err := c.GetAncestry(reportName)
 	if err != nil {
 		return report, err
 	}

--- a/clair/vulns.go
+++ b/clair/vulns.go
@@ -19,7 +19,7 @@ func (c *Clair) Vulnerabilities(r *registry.Registry, repo, tag string) (Vulnera
 		VulnsBySeverity: make(map[string][]Vulnerability),
 	}
 
-	filteredLayers, reportName, err := c.getLayers(r, repo, tag, true)
+	filteredLayers, _, err := c.getLayers(r, repo, tag, true)
 	if err != nil {
 		return report, fmt.Errorf("getting filtered layers failed: %v", err)
 	}
@@ -42,9 +42,9 @@ func (c *Clair) Vulnerabilities(r *registry.Registry, repo, tag string) (Vulnera
 		}
 	}
 
-	report.Name = reportName
+	report.Name = filteredLayers[0].Digest.String()
 
-	vl, err := c.GetLayer(reportName, true, true)
+	vl, err := c.GetLayer(filteredLayers[0].Digest.String(), true, true)
 	if err != nil {
 		return report, err
 	}


### PR DESCRIPTION
Rather than pull the manifest a second time I changed the output of the internal method for getting the layers, hope that's not too much of an issue.

For registry manifest V1 schemas it's still returning the `layer[0]` digest which isn't perfect but also doesn't sound the easiest to solve unless we use the fully qualified image reference but as @jzelinskie suggests that's also not ideal.