### PR TITLE
Closing of gRPC connection

### DIFF
--- a/clair/clair.go
+++ b/clair/clair.go
@@ -81,6 +81,11 @@ func New(url string, opt Opt) (*Clair, error) {
 	return registry, nil
 }
 
+// Close closes the gRPC connection
+func (c *Clair) Close() error {
+	return c.grpcConn.Close()
+}
+
 // url returns a clair URL with the passed arguements concatenated.
 func (c *Clair) url(pathTemplate string, args ...interface{}) string {
 	pathSuffix := fmt.Sprintf(pathTemplate, args...)


### PR DESCRIPTION
In my usage I noticed I could call a Clair scan but the connection wasn't cleaned up and as `grpcConn` isn't exposed I couldn't access the connection directly to handle safe closure.