### PR TITLE
Check response interface for type instead of setting bool

### DIFF
--- a/registry/catalog.go
+++ b/registry/catalog.go
@@ -19,7 +19,7 @@ func (r *Registry) Catalog(u string) ([]string, error) {
 	r.Logf("registry.catalog url=%s", uri)
 
 	var response catalogResponse
-	h, err := r.getJSON(uri, &response, false)
+	h, err := r.getJSON(uri, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/manifest.go
+++ b/registry/manifest.go
@@ -51,7 +51,7 @@ func (r *Registry) ManifestList(repository, ref string) (manifestlist.ManifestLi
 	r.Logf("registry.manifests uri=%s repository=%s ref=%s", uri, repository, ref)
 
 	var m manifestlist.ManifestList
-	if _, err := r.getJSON(uri, &m, true); err != nil {
+	if _, err := r.getJSON(uri, &m); err != nil {
 		r.Logf("registry.manifests response=%v", m)
 		return m, err
 	}
@@ -65,7 +65,7 @@ func (r *Registry) ManifestV2(repository, ref string) (schema2.Manifest, error) 
 	r.Logf("registry.manifests uri=%s repository=%s ref=%s", uri, repository, ref)
 
 	var m schema2.Manifest
-	if _, err := r.getJSON(uri, &m, true); err != nil {
+	if _, err := r.getJSON(uri, &m); err != nil {
 		r.Logf("registry.manifests response=%v", m)
 		return m, err
 	}
@@ -79,7 +79,7 @@ func (r *Registry) ManifestV1(repository, ref string) (schema1.SignedManifest, e
 	r.Logf("registry.manifests uri=%s repository=%s ref=%s", uri, repository, ref)
 
 	var m schema1.SignedManifest
-	if _, err := r.getJSON(uri, &m, false); err != nil {
+	if _, err := r.getJSON(uri, &m); err != nil {
 		r.Logf("registry.manifests response=%v", m)
 		return m, err
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -124,14 +124,19 @@ func (r *Registry) url(pathTemplate string, args ...interface{}) string {
 	return url
 }
 
-func (r *Registry) getJSON(url string, response interface{}, addV2Header bool) (http.Header, error) {
+func (r *Registry) getJSON(url string, response interface{}) (http.Header, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
-	if addV2Header {
-		req.Header.Add("Accept", fmt.Sprintf("%s,%s;q=0.9", schema2.MediaTypeManifest, manifestlist.MediaTypeManifestList))
+
+	switch response.(type) {
+	case *schema2.Manifest:
+		req.Header.Add("Accept", fmt.Sprintf("%s;q=0.9", schema2.MediaTypeManifest))
+	case *manifestlist.ManifestList:
+		req.Header.Add("Accept", fmt.Sprintf("%s;q=0.9", manifestlist.MediaTypeManifestList))
 	}
+
 	resp, err := r.Client.Do(req)
 	if err != nil {
 		return nil, err

--- a/registry/tags.go
+++ b/registry/tags.go
@@ -10,7 +10,7 @@ func (r *Registry) Tags(repository string) ([]string, error) {
 	r.Logf("registry.tags url=%s repository=%s", url, repository)
 
 	var response tagsResponse
-	if _, err := r.getJSON(url, &response, false); err != nil {
+	if _, err := r.getJSON(url, &response); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This fixes #132 without removing the possibility of still being able to use `ManifestList` and `ManifestV2` methods independently.

As the switch case will not add any headers if the type is not of `*schema2.Manifest` or `*manifestlist.ManifestList` I no longer saw the requirement for the `addV2Header` bool so I've cleaned that up.