### PR TITLE
Fix token transport memory leak

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -37,6 +37,8 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return resp, nil
 	}
 
+	resp.Body.Close()
+
 	return t.authAndRetry(authService, req)
 }
 

--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -29,6 +29,7 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	authService, err := isTokenDemand(resp)
 	if err != nil {
+		resp.Body.Close()
 		return nil, err
 	}
 

--- a/registry/tokentransport_test.go
+++ b/registry/tokentransport_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -89,5 +90,60 @@ func TestBothTokenAndAccessTokenWork(t *testing.T) {
 		if token == "" {
 			t.Fatalf("error got empty token")
 		}
+	}
+}
+
+type testTransport func(*http.Request) (*http.Response, error)
+
+func (tt testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return tt(req)
+}
+
+func TestTokenTransportErrorHandling(t *testing.T) {
+	tokenTransport := &TokenTransport{
+		Transport: testTransport(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("transport failed")
+		}),
+	}
+	_, err := tokenTransport.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+	if err == nil {
+		t.Fatalf("got no error from round trip: %s", err)
+	}
+}
+
+type testBody struct {
+	t      *testing.T
+	closed bool
+}
+
+func (tb *testBody) Read(p []byte) (n int, err error) {
+	tb.t.Helper()
+	panic("unexpected read")
+}
+
+func (tb *testBody) Close() error {
+	tb.closed = true
+	return nil
+}
+
+func TestTokenTransportTokenDemandErr(t *testing.T) {
+	body := &testBody{t: t}
+	tokenTransport := &TokenTransport{
+		Transport: testTransport(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body:       body,
+				StatusCode: http.StatusUnauthorized,
+			}, nil
+		}),
+	}
+	resp, err := tokenTransport.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+	if err == nil {
+		t.Fatal("Expected error due to missing auth challenge header, got none")
+	}
+	if resp != nil {
+		t.Fatal("Expected no response")
+	}
+	if !body.closed {
+		t.Fatal("Expected body to be closed")
 	}
 }


### PR DESCRIPTION
Hey,

we're only using your `registry` package and found out that when the package is used for successive authenticated requests, the memory usage of the process increased. We followed this back to missing `resp.Body.Close()` in specific cases.

This PR adds the missing calls and also some tests proving the issue and helping it from happening again.

We would be happy about a review and a merge!

Keep up the good work!
Pirmin