### PR TITLE
server: add sort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,22 +225,24 @@ Run a static UI server for a registry.
 
 Flags:
 
-  -u, --username       username for the registry (default: <none>)
-  --listen-address     address to listen on (default: <none>)
   --asset-path         Path to assets and templates (default: <none>)
-  -f, --force-non-ssl  force allow use of non-ssl (default: false)
-  --once               generate the templates once and then exit (default: false)
-  --skip-ping          skip pinging the registry while establishing connection (default: false)
-  --timeout            timeout for HTTP requests (default: 1m0s)
+  --auth-url           alternate URL for registry authentication (ex. auth.docker.io) (default: <none>)
   --cert               path to ssl cert (default: <none>)
+  --clair              url to clair instance (default: <none>)
   -d                   enable debug logging (default: false)
+  -f, --force-non-ssl  force allow use of non-ssl (default: false)
+  --interval           interval to generate new index.html's at (default: 1h0m0s)
+  -k, --insecure       do not verify tls certificates (default: false)
   --key                path to ssl key (default: <none>)
+  --listen-address     address to listen on (default: <none>)
+  --once               generate the templates once and then exit (default: false)
+  -p, --password       password for the registry (default: <none>)
   --port               port for server to run on (default: 8080)
   -r, --registry       URL to the private registry (ex. r.j3ss.co) (default: <none>)
-  --clair              url to clair instance (default: <none>)
-  -k, --insecure       do not verify tls certificates (default: false)
-  --interval           interval to generate new index.html's at (default: 1h0m0s)
-  -p, --password       password for the registry (default: <none>)
+  --skip-ping          skip pinging the registry while establishing connection (default: false)
+  --sort               generate tag templates sorted by property (one of: created) (default: created)
+  --timeout            timeout for HTTP requests (default: 1m0s)
+  -u, --username       username for the registry (default: <none>)
 ```
 
 **Screenshots:**

--- a/server.go
+++ b/server.go
@@ -43,6 +43,10 @@ func (cmd *serverCommand) Register(fs *flag.FlagSet) {
 	fs.StringVar(&cmd.assetPath, "asset-path", "", "Path to assets and templates")
 
 	fs.BoolVar(&cmd.generateAndExit, "once", false, "generate the templates once and then exit")
+
+	sortOpts := []string{sortByCreated}
+	fs.StringVar(&cmd.repoSortBy, "sort", sortByCreated,
+		fmt.Sprintf("generate tag templates sorted by property (one of: %s)", strings.Join(sortOpts, ",")))
 }
 
 type serverCommand struct {
@@ -57,6 +61,7 @@ type serverCommand struct {
 	listenAddress string
 	port          string
 	assetPath     string
+	repoSortBy    string
 }
 
 func (cmd *serverCommand) Run(ctx context.Context, args []string) error {
@@ -66,10 +71,15 @@ func (cmd *serverCommand) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	if cmd.repoSortBy != sortByCreated {
+		return fmt.Errorf("sort option invalid; '%s' is not valid", cmd.repoSortBy)
+	}
+
 	// Create the registry controller for the handlers.
 	rc := registryController{
 		reg:          r,
 		generateOnly: cmd.generateAndExit,
+		repoSortBy:   cmd.repoSortBy,
 	}
 
 	// Create a clair client if the user passed in a server address.


### PR DESCRIPTION
This adds a '--sort' to the 'server' sub-command. Currently there is
only one sort option, which is by create date. I assumed that his is
useful in general, compared to a random order, so I made this the
default.

This is slightly over engineered, but makes it easier to add additional
sorting options later. One that comes to my mind is sorting by tag (some
kind of natsort/semversort).

Signed-off-by: Roland Kammerer <roland.kammerer@linbit.com>