### PR TITLE
Use default client when pinging registry.

### DIFF
--- a/registry/ping.go
+++ b/registry/ping.go
@@ -13,7 +13,7 @@ func (r *Registry) Ping(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := r.Client.Do(req.WithContext(ctx))
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
 	if resp != nil {
 		defer resp.Body.Close()
 	}


### PR DESCRIPTION
As this code doesn't check for status code, there's
no need to use custom transports to authenticate.
For what I see it's only checking there is no communication issue

I couldn't run tests due to #187 but for what I see it shouldn't break anything.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>