### PR TITLE
change Ping to check for Docker header

### DIFF
--- a/registry/ping_test.go
+++ b/registry/ping_test.go
@@ -1,31 +1,94 @@
 package registry
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/docker/docker/api/types"
 )
 
+func createClientAndPing(httpCode int, headerName string, headerValue string) (*Registry, func(), error) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(headerName, headerValue)
+		w.WriteHeader(httpCode)
+	}))
+
+	auth := types.AuthConfig{ServerAddress: ts.URL}
+	r, err := New(context.Background(), auth, Opt{Insecure: true})
+	return r, ts.Close, err
+}
+
+func TestPing(t *testing.T) {
+	testcases := []struct {
+		httpCode    int
+		headerName  string
+		headerValue string
+		want        error
+	}{
+		{
+			httpCode:    200,
+			headerName:  "whatever",
+			headerValue: "whatever",
+			want:        ErrNoDockerHeader,
+		},
+		{
+			httpCode:    401,
+			headerName:  "wrong",
+			headerValue: "whatever",
+			want:        ErrNoDockerHeader,
+		},
+		{
+			httpCode:    200,
+			headerName:  "docker-distribution-api-version",
+			headerValue: "registry/2.0",
+			want:        nil,
+		},
+		{
+			httpCode:    401,
+			headerName:  "Docker-Distribution-API-Version",
+			headerValue: "registry/2.1",
+			// Many popular servers do allow unauthenticated image pulls, but require authentication to visit the base url.
+			// This conforms to Docker Registry v2 API Specification https://docs.docker.com/registry/spec/api/
+			// Thus `401 Unauthorized` is as good response as `200 OK`, if only it has the proper Docker header.
+			want: nil,
+		},
+	}
+	for _, tc := range testcases {
+		r, closeFunc, err := createClientAndPing(tc.httpCode, tc.headerName, tc.headerValue)
+		defer closeFunc()
+		if err != tc.want {
+			t.Fatalf("when creating client and performing ping for (%v, %q, %q), got error %#v but expected %#v", tc.httpCode, tc.headerName, tc.headerValue, err, tc.want)
+		}
+		if err != nil {
+			continue
+		}
+		err = r.Ping(context.Background())
+		if err != tc.want {
+			t.Fatalf("when repeating ping for (%v, %q, %q), got error %#v but expected %#v", tc.httpCode, tc.headerName, tc.headerValue, err, tc.want)
+		}
+	}
+}
+
 func TestPingable(t *testing.T) {
-	testcases := map[string]struct {
+	testcases := []struct {
 		registry Registry
 		expect   bool
 	}{
-		"Docker": {
+		{
 			registry: Registry{URL: "https://registry-1.docker.io"},
 			expect:   true,
 		},
-		"GCR_global": {
-			registry: Registry{URL: "https://gcr.io"},
-			expect:   false,
-		},
-		"GCR_asia": {
+		{
 			registry: Registry{URL: "https://asia.gcr.io"},
-			expect:   false,
+			expect:   true,
 		},
 	}
-	for label, testcase := range testcases {
+	for _, testcase := range testcases {
 		actual := testcase.registry.Pingable()
 		if testcase.expect != actual {
-			t.Fatalf("%s: expected (%v), got (%v)", label, testcase.expect, actual)
+			t.Fatalf("%s pingable: expected (%v), got (%v)", testcase.registry.URL, testcase.expect, actual)
 		}
 	}
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -18,13 +18,14 @@ import (
 
 // Registry defines the client for retrieving information from the registry API.
 type Registry struct {
-	URL      string
-	Domain   string
-	Username string
-	Password string
-	Client   *http.Client
-	Logf     LogfCallback
-	Opt      Opt
+	URL        string
+	Domain     string
+	Username   string
+	Password   string
+	Client     *http.Client
+	PingClient *http.Client
+	Logf       LogfCallback
+	Opt        Opt
 }
 
 var reProtocol = regexp.MustCompile("^https?://")
@@ -120,6 +121,13 @@ func newFromTransport(ctx context.Context, auth types.AuthConfig, transport http
 		Client: &http.Client{
 			Timeout:   opt.Timeout,
 			Transport: customTransport,
+		},
+		PingClient: &http.Client{
+			Timeout: opt.Timeout,
+			Transport: &CustomTransport{
+				Transport: transport,
+				Headers:   opt.Headers,
+			},
 		},
 		Username: auth.Username,
 		Password: auth.Password,

--- a/registry/tokentransport_test.go
+++ b/registry/tokentransport_test.go
@@ -14,6 +14,7 @@ import (
 func TestErrBasicAuth(t *testing.T) {
 	ctx := context.Background()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
 		if r.URL.Path == "/" {
 			w.Header().Set("www-authenticate", `Basic realm="Registry Realm",service="Docker registry"`)
 			w.WriteHeader(http.StatusUnauthorized)
@@ -44,6 +45,7 @@ func TestErrBasicAuth(t *testing.T) {
 var authURI string
 
 func oauthFlow(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
 	if strings.HasPrefix(r.URL.Path, "/oauth2/accesstoken") {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Change Registry.Ping() to:
  - respect http 401 response code as valid
  - conform to the Specs by requiring header
    Docker-Distribution-API-Version

Change the TokenTransport unit tests to emit that header.

Remove the naive workaround inside Registry.Pingable() as
iterating over all sites that do not support the old
ping would require huge and constant effort. (Not only GCR.)

I add separate Registry.PingClient, because the Client handles 401
by closing the body so it disables the possibility of disinguishing
whether the 401 contained Docker-Distribution-API-Version header.

Refactor: simplify current TestPingable

Closes #198