### PR TITLE
Fix row cell index for server searching feature

### DIFF
--- a/server/static/js/scripts.js
+++ b/server/static/js/scripts.js
@@ -23,7 +23,7 @@ function prettyDate(time){
 function search(search_val){
     var suche = search_val.toLowerCase();
     var table = document.getElementById("directory");
-    var cellNr = 1;
+    var cellNr = 0;
     var ele;
     for (var r = 1; r < table.rows.length; r++){
         ele = table.rows[r].cells[cellNr].innerHTML.replace(/<[^>]+>/g,"");


### PR DESCRIPTION
The HTML template for repositories carries the container image name in
the first cell of each entry in the table. This patch adjusts the JS
search function to fetch the image name information from that cell.

Signed-off-by: Athos Ribeiro <athoscr@fedoraproject.org>