### PR TITLE
Do not pass empty service param to auth challenge

### DIFF
--- a/registry/tokentransport.go
+++ b/registry/tokentransport.go
@@ -113,7 +113,9 @@ type authService struct {
 
 func (a *authService) Request(username, password string) (*http.Request, error) {
 	q := a.Realm.Query()
-	q.Set("service", a.Service)
+	if len(a.Service) > 0 {
+		q.Set("service", a.Service)
+	}
 	for _, s := range a.Scope {
 		q.Set("scope", s)
 	}


### PR DESCRIPTION
When an auth challenge does not contain a value for service there is no
point in passing an empty value to the challenge endpoint. Moreover, not
passing an empty values makes it easier for a proxy [1] to omit the
service name from a client and set it before forwarding a request.

[1] https://docs.docker.com/registry/recipes/nginx/

Signed-off-by: Athos Ribeiro <athoscr@fedoraproject.org>