### PR TITLE
Add support for client certificates

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,10 @@ var (
 	username string
 	password string
 
+	tlsCACert string
+	tlsCert   string
+	tlsKey    string
+
 	debug bool
 )
 
@@ -72,6 +76,10 @@ func main() {
 
 	p.FlagSet.StringVar(&password, "password", "", "password for the registry")
 	p.FlagSet.StringVar(&password, "p", "", "password for the registry")
+
+	p.FlagSet.StringVar(&tlsCACert, "tlscacert", "", "Trust certs signed only by this CA")
+	p.FlagSet.StringVar(&tlsCert, "tlscert", "", "Path to TLS certificate file")
+	p.FlagSet.StringVar(&tlsKey, "tlskey", "", "Path to TLS key file")
 
 	p.FlagSet.BoolVar(&debug, "d", false, "enable debug logging")
 
@@ -122,6 +130,9 @@ func createRegistryClient(ctx context.Context, domain string) (*registry.Registr
 	logrus.Infof("domain: %s", domain)
 	logrus.Infof("server address: %s", auth.ServerAddress)
 	return registry.New(ctx, auth, registry.Opt{
+		CAFile:   tlsCACert,
+		CertFile: tlsCert,
+		KeyFile:  tlsKey,
 		Domain:   domain,
 		Insecure: insecure,
 		Debug:    debug,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -14,12 +14,14 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/go-connections/tlsconfig"
 )
 
 // Registry defines the client for retrieving information from the registry API.
 type Registry struct {
 	URL      string
 	Domain   string
+	Insecure bool
 	Username string
 	Password string
 	Client   *http.Client
@@ -43,6 +45,9 @@ func Log(format string, args ...interface{}) {
 // Opt holds the options for a new registry.
 type Opt struct {
 	Domain   string
+	CAFile   string
+	CertFile string
+	KeyFile  string
 	Insecure bool
 	Debug    bool
 	SkipPing bool
@@ -60,6 +65,16 @@ func New(ctx context.Context, auth types.AuthConfig, opt Opt) (*Registry, error)
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},
+		}
+	} else {
+		tlsClientConfig, _ := tlsconfig.Client(
+			tlsconfig.Options{
+				CAFile:   opt.CAFile,
+				CertFile: opt.CertFile,
+				KeyFile:  opt.KeyFile,
+			})
+		transport = &http.Transport{
+			TLSClientConfig: tlsClientConfig,
 		}
 	}
 


### PR DESCRIPTION
Add options:

```
  --tlscacert          Trust certs signed only by this CA (default: <none>)
  --tlscert            Path to TLS certificate file (default: <none>)
  --tlskey             Path to TLS key file (default: <none>)
```

Fixes https://github.com/genuinetools/reg/issues/189